### PR TITLE
Feature: full CRUD on ingredientAmounts, user.uid on recipes

### DIFF
--- a/src/components/DynamicIngredientFields.js
+++ b/src/components/DynamicIngredientFields.js
@@ -15,17 +15,18 @@ function DynamicIngredientFields({ value, onChange }) {
   const [counter, setCounter] = useState(0);
 
   const handleClickAdd = () => {
-    setIngredientAmounts((prev) => [...prev, { size: '', amount: '', ingredient: { id: '' } }]);
+    onChange([...value, { size: '', amount: '', ingredient: { id: '' } }]);
     setCounter(counter + 1);
   };
   const handleClickRemove = () => {
     if (counter > 0) {
-      setIngredientAmounts((prev) => prev.slice(0, -1));
+      onChange(value.slice(0, -1));
       setCounter(counter - 1);
     }
   };
 
   const handleLocalChange = (e, index, fieldName) => {
+    console.warn(ingredientAmounts);
     const newAmounts = [...ingredientAmounts];
     newAmounts[index] = {
       ...newAmounts[index],

--- a/src/components/IngredientSelector.js
+++ b/src/components/IngredientSelector.js
@@ -13,7 +13,7 @@ function IngredientSelector({ value, onChange }) {
 
   return (
     <div>
-      <Form.Select id="ingredient_id" name="ingredient_id" value={value} onChange={onChange} required>
+      <Form.Select id={`${value}`} name="ingredient_id" value={value} onChange={onChange} required>
         <option value="">Select ingredient</option>
         {ingredients.map((ingredient) => (
           <option key={ingredient.id} value={ingredient.id}>

--- a/src/components/forms/RecipeForm.js
+++ b/src/components/forms/RecipeForm.js
@@ -1,13 +1,21 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Form, InputGroup, Button } from 'react-bootstrap';
+
+import firebase from 'firebase';
+import 'firebase/auth';
+
 import PropTypes from 'prop-types';
+
 import { getSingleRecipe, createRecipe, updateRecipe } from '../../utils/data/recipe_data';
-import { addIngredientToRecipe } from '../../utils/data/ingredient_data';
+import { addIngredientToRecipe, removeAllIngredients } from '../../utils/data/ingredient_data';
 import CategorySelector from '../CategorySelector';
 import DynamicIngredientFields from '../DynamicIngredientFields';
 
 function RecipeForm({ recipeId }) {
+  const auth = firebase.auth();
+  const user = auth.currentUser;
+
   const router = useRouter();
 
   const [recipe, setRecipe] = useState({
@@ -30,6 +38,7 @@ function RecipeForm({ recipeId }) {
   };
   const handleIngredientChange = (newIngredients) => {
     const updatedData = { ...recipe, ingredient_amounts: newIngredients };
+    console.warn('RecipeForm: handleIngredientChange: newIngredients=', newIngredients);
     setRecipe(updatedData);
   };
 
@@ -39,7 +48,7 @@ function RecipeForm({ recipeId }) {
     try {
       const recipeData = {
         ...recipe,
-        creator_id: 'default_user', // FIXME: get user firebaseKey here
+        creator_id: user.uid, // FIXME: get user firebaseKey here
       };
 
       if (!recipeId) {
@@ -56,10 +65,20 @@ function RecipeForm({ recipeId }) {
         router.push(`/recipes?category_id=${recipeData.category_id}`);
       } else {
         await updateRecipe(recipeId, recipeData);
+        await removeAllIngredients(recipeId);
+        recipeData.ingredient_amounts.map((ingredientAmount) => {
+          const JSONpayload = {
+            size: ingredientAmount.size,
+            ingredient: ingredientAmount.ingredient.id,
+            amount: ingredientAmount.amount,
+          };
+          const response = addIngredientToRecipe(recipeId, JSONpayload);
+          return response;
+        });
         router.push(`/recipes?category_id=${recipeData.category_id}`);
       }
     } catch (err) {
-      console.error(err);
+      console.error(err, 'recipe= ', recipe, ' recipeId= ', recipeId);
     }
   };
 

--- a/src/utils/data/ingredient_data.js
+++ b/src/utils/data/ingredient_data.js
@@ -40,4 +40,13 @@ const removeIngredientFromRecipe = async (recipeId, ingredientPayload) => {
   });
 };
 
-export { getIngredients, getSingleIngredient, addIngredientToRecipe, removeIngredientFromRecipe };
+const removeAllIngredients = async (recipeId) => {
+  await fetch(`${clientCredentials.databaseURL}/recipes/${recipeId}/remove-ingredients`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+};
+
+export { getIngredients, getSingleIngredient, addIngredientToRecipe, removeIngredientFromRecipe, removeAllIngredients };


### PR DESCRIPTION
## What?
- User can now remove ingredientAmount objects from a recipe

## Why?
- Core MVP functionality

## How?
- Upon updating a recipe, removes all ingredientAmounts on the object, then replaces them with the updated values. Also adds in the user's firebase key as creator_id

## Testing?
- Using the edit recipe form, edit any recipe and remove an ingredient amount. Save the object. Check to see if changes saved.

## Screenshots (optional)

## Anything Else?
