### PR TITLE
Feature: Look up a recipe from a Square order

### DIFF
--- a/src/app/ticketrail/page.js
+++ b/src/app/ticketrail/page.js
@@ -1,30 +1,31 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { getOrders, getCompleteOrders, completeOrder, deleteCompletedOrder } from '../../utils/data/square_data';
+import { getRecipes } from '../../utils/data/recipe_data';
 
 export default function TicketRail() {
+  const router = useRouter();
   const [orders, setOrders] = useState([]);
-  // eslint-disable-next-line no-unused-vars
-  const [completedOrders, setCompletedOrders] = useState([]);
   const [completedIds, setCompletedIds] = useState([]);
+  const [recipes, setRecipes] = useState([]);
 
   const clearCompletedData = () => {
     if (completedIds.length >= 10) {
-      console.warn(completedIds[0]);
       deleteCompletedOrder(completedIds[0].order_id);
     }
   };
 
   const handleComplete = (order) => {
     completeOrder({ order_id: order.id });
-    setCompletedOrders((prev) => [...prev, order]);
     clearCompletedData();
   };
 
   useEffect(() => {
     const interval = setInterval(() => {
       getOrders().then(setOrders);
+      getRecipes('').then(setRecipes);
       getCompleteOrders().then(setCompletedIds);
     }, 3000);
 
@@ -46,6 +47,13 @@ export default function TicketRail() {
               {itemNames.map((itemName, index) => (
                 <p>
                   {quantities[index]}x {itemName}
+                  {recipes?.some((recipe) => recipe.label === itemName) ? (
+                    <button type="button" onClick={() => router.push(`/recipes/${recipes.find((recipe) => recipe.label === itemName).id}`)}>
+                      Recipe
+                    </button>
+                  ) : (
+                    ''
+                  )}
                 </p>
               ))}
               <button type="button" onClick={() => handleComplete(order)}>


### PR DESCRIPTION
## What?
- The user now has a button next to each item on a Square order ticket that they can click on which will navigate to the recipe for the corresponding item

## Why?
- This will greatly assist in consistency and speed as a barista can see a recipe for an item that has been ordered at the touch of a button

## How?
- Get and store recipes in a `useState([])` within `ticketrail/page.js`; then `.find()` the recipe matching the item's name and have the router push the recipe's id when the button is clicked.

## Testing?
- After placing a Square order in the sandbox, navigate to the Ticket Rail and there should be a Recipe button. Click on it and it should take you to the item's recipe detail page.

## Screenshots (optional)

## Anything Else?
