### PR TITLE
Managers only can edit, create, and delete now

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 
 import { Button, Modal, Form } from 'react-bootstrap';
 import { getCategories, createCategory, deleteCategory, updateCategory } from '../utils/data/category_data';
+import getUserInfo from '../utils/data/userinfo_data';
 
 function Home() {
   const auth = firebase.auth();
@@ -18,6 +19,7 @@ function Home() {
   const [editId, setEditId] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [editMode, setEditMode] = useState(false);
+  const [userInfo, setUserInfo] = useState({});
 
   const handleClose = () => setShowModal(false);
   const handleShowModal = () => setShowModal(true);
@@ -25,6 +27,9 @@ function Home() {
   useEffect(() => {
     getCategories().then(setCategories);
   }, []);
+  useEffect(() => {
+    getUserInfo(user.uid).then(setUserInfo);
+  }, [user.uid]);
 
   return (
     <div
@@ -79,9 +84,13 @@ function Home() {
         ))}
       </div>
       <div>
-        <Button className="btn-new" onClick={handleShowModal}>
-          + New Category
-        </Button>
+        {userInfo.is_manager ? (
+          <Button className="btn-new" onClick={handleShowModal}>
+            + New Category
+          </Button>
+        ) : (
+          ''
+        )}
 
         <Modal className="category-modal" show={showModal} onHide={handleClose}>
           <Modal.Header closeButton>

--- a/src/app/recipes/edit/[id]/page.js
+++ b/src/app/recipes/edit/[id]/page.js
@@ -1,16 +1,36 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+
 import { useParams } from 'next/navigation';
 import RecipeForm from '../../../../components/forms/RecipeForm';
+import getUserInfo from '../../../../utils/data/userinfo_data';
 
 export default function EditRecipePage() {
+  const auth = firebase.auth();
+  const user = auth.currentUser;
+
+  const [userInfo, setUserInfo] = useState({});
+
+  useEffect(() => {
+    getUserInfo(user.uid).then(setUserInfo);
+  }, [user.uid]);
+
   const { id } = useParams();
 
   return (
     <div>
-      <h1>Edit Recipe</h1>
       <title>Edit Recipe</title>
-      <RecipeForm recipeId={id} />
+      {userInfo.is_manager ? (
+        <>
+          <h1>Edit Recipe</h1>
+          <RecipeForm recipeId={id} />
+        </>
+      ) : (
+        <h1>Not authorized</h1>
+      )}
     </div>
   );
 }

--- a/src/app/recipes/new/page.js
+++ b/src/app/recipes/new/page.js
@@ -1,13 +1,33 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+
 import RecipeForm from '../../../components/forms/RecipeForm';
+import getUserInfo from '../../../utils/data/userinfo_data';
 
 export default function NewRecipePage() {
+  const auth = firebase.auth();
+  const user = auth.currentUser;
+
+  const [userInfo, setUserInfo] = useState({});
+
+  useEffect(() => {
+    getUserInfo(user.uid).then(setUserInfo);
+  }, [user.uid]);
+
   return (
     <div>
       <title>New Recipe</title>
-      <h1>New Recipe</h1>
-      <RecipeForm />
+      {userInfo.is_manager ? (
+        <>
+          <h1>New Recipe</h1>
+          <RecipeForm />
+        </>
+      ) : (
+        <h1>Not authorized</h1>
+      )}
     </div>
   );
 }

--- a/src/app/recipes/page.js
+++ b/src/app/recipes/page.js
@@ -6,11 +6,12 @@ import { Button, Form } from 'react-bootstrap';
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import { getRecipes, deleteRecipe } from '../../utils/data/recipe_data';
+import getUserInfo from '../../utils/data/userinfo_data';
 
 export default function RecipesPage() {
   const auth = firebase.auth();
   const user = auth.currentUser;
-
+  const [userInfo, setUserInfo] = useState({});
   const [recipesArray, setRecipesArray] = useState([]);
   const [filteredRecipes, setFilteredRecipes] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -27,6 +28,10 @@ export default function RecipesPage() {
       setRecipesArray(filteredData);
     }
   }, [query, searchTerm, filteredRecipes]);
+
+  useEffect(() => {
+    getUserInfo(user.uid).then(setUserInfo);
+  }, [user.uid]);
 
   const handleSearch = (e) => {
     setSearchTerm(e.target.value);
@@ -86,9 +91,13 @@ export default function RecipesPage() {
         ))}
       </div>
       <div>
-        <Button className="btn btn-success" onClick={() => router.push('/recipes/new')}>
-          + New Recipe
-        </Button>
+        {userInfo.is_manager ? (
+          <Button className="btn btn-success" onClick={() => router.push('/recipes/new')}>
+            + New Recipe
+          </Button>
+        ) : (
+          ''
+        )}
       </div>
     </div>
   );

--- a/src/utils/data/category_data.js
+++ b/src/utils/data/category_data.js
@@ -6,6 +6,7 @@ const getCategories = async () => {
     headers: {
       'Content-Type': 'application/json',
     },
+    mode: 'cors',
   });
   return response.json();
 };

--- a/src/utils/data/userinfo_data.js
+++ b/src/utils/data/userinfo_data.js
@@ -1,0 +1,13 @@
+import { clientCredentials } from '../client';
+
+const getUserInfo = async (uid) => {
+  const response = await fetch(`${clientCredentials.databaseURL}/user-info/${uid}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  return response.json();
+};
+
+export default getUserInfo;


### PR DESCRIPTION
## What?
- This update makes it so that only users who are managers can create, edit, update, or delete. All other users can read only.

## Why?
- User role separation

## How?
- Grab the data from the `user_info` table through the API, then check to see if the corresponding user (via matching firebaseKey) `is_manager` or is not. If not, the buttons and components necessary to edit do not appear.

## Testing?
- Log in as a manager user and check to see if you can access create and edit pages. Log in as a non-manager user and make sure you cannot.

## Screenshots (optional)

## Anything Else?
- Non manager users would still be able to edit and delete anything with their respective firebase key as the creator_id, but would be prevented from creating new entries.
